### PR TITLE
Export Canvas to PPM Format String

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.2.2"
 edition = "2021"
 
 [dependencies]
+rayon = "1.5"
 
 [dev-dependencies]
 async-trait = "0.1"
 cucumber = { version = "0.11", features = ["output-junit"] }
 futures = "0.3"
-rayon = "1.5"
 
 [[test]]
 name = "tuples"

--- a/src/float.rs
+++ b/src/float.rs
@@ -71,6 +71,14 @@ impl std::ops::Mul<Self> for Float {
     }
 }
 
+impl std::ops::Mul<u8> for Float {
+    type Output = f64;
+
+    fn mul(self, rhs: u8) -> Self::Output {
+        self.0 * (rhs as f64)
+    }
+}
+
 impl std::ops::Div<Self> for Float {
     type Output = Self;
 

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -77,7 +77,7 @@ fn build_ppm_string_from_pixels(pixels: &[Color], width: &usize) -> (String, usi
     srgb_pixels.iter().enumerate().fold(
         (String::new(), 0),
         |(mut body, mut line_length), (index, color_channel)| {
-            if index != 0 && index % flattened_width == 0 {
+            if index % flattened_width == 0 {
                 body.push('\n');
                 line_length = 0;
             }
@@ -91,17 +91,20 @@ fn build_ppm_string_from_pixels(pixels: &[Color], width: &usize) -> (String, usi
 }
 
 pub fn canvas_to_ppm(canvas: &Canvas) -> String {
-    let mut ppm_file = format!("{}\n", PPM_VERSION);
-    ppm_file.push_str(&format!(
-        "{width} {height}\n",
+    let mut ppm_file = format!(
+        "{ppm_version}\n{width} {height}\n{rgb_value_limit}",
+        ppm_version = PPM_VERSION,
         width = canvas.width,
-        height = canvas.height
-    ));
-    ppm_file.push_str(&format!("{}\n", MAX_SRGB_VALUE));
+        height = canvas.height,
+        rgb_value_limit = MAX_SRGB_VALUE,
+    );
 
     let (body, _) = build_ppm_string_from_pixels(&canvas.pixels, &canvas.width);
 
     ppm_file.push_str(&body);
+
+    // ensure file ends with a line break for compatibility with all PPM3 readers
+    ppm_file.push('\n');
 
     ppm_file
 }

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -1,4 +1,7 @@
 use crate::graphics::Color;
+use crate::Float;
+
+use rayon::prelude::*;
 
 #[derive(Debug)]
 pub struct Canvas {
@@ -18,7 +21,74 @@ pub fn pixel_at(canvas: &Canvas, x: usize, y: usize) -> Color {
 }
 
 const PPM_VERSION: &str = "P3";
-const MAX_COLOR_VALUE: u8 = 255;
+const MIN_SRGB_VALUE: u8 = 0;
+const MAX_SRGB_VALUE: u8 = 255;
+
+fn scale_to_srgb(value: Float) -> u8 {
+    let result = (value * MAX_SRGB_VALUE).round() as i64;
+
+    if result <= MIN_SRGB_VALUE as i64 {
+        return MIN_SRGB_VALUE;
+    } else if result >= MAX_SRGB_VALUE as i64 {
+        return MAX_SRGB_VALUE;
+    }
+
+    result as u8
+}
+
+fn convert_srgb_channel_to_ppm_string(
+    color_channel: &u8,
+    mut line_length: usize,
+) -> (String, usize) {
+    const PPM_MAX_LINE_LENGTH: u8 = 70;
+
+    let mut result = String::new();
+
+    let color_channel_string_length = color_channel.to_string().chars().count();
+
+    if line_length + color_channel_string_length > (PPM_MAX_LINE_LENGTH - 1) as usize {
+        result.push('\n');
+        line_length = 0;
+    } else if line_length > 0 {
+        result.push(' ');
+        line_length += 1;
+    }
+
+    result.push_str(&color_channel.to_string());
+    line_length += color_channel_string_length;
+    (result, line_length)
+}
+
+fn build_ppm_string_from_pixels(pixels: &[Color], width: &usize) -> (String, usize) {
+    let srgb_pixels = pixels
+        .into_par_iter()
+        .flat_map_iter(|color| {
+            color
+                .into_array()
+                .iter()
+                .map(|channel| scale_to_srgb(*channel))
+                .collect::<Vec<u8>>()
+        })
+        .collect::<Vec<u8>>();
+
+    // each row of pixels is now 3X as long after flattening the color channels
+    let flattened_width: usize = width * 3;
+
+    srgb_pixels.iter().enumerate().fold(
+        (String::new(), 0),
+        |(mut body, mut line_length), (index, color_channel)| {
+            if index != 0 && index % flattened_width == 0 {
+                body.push('\n');
+                line_length = 0;
+            }
+
+            let (channel_as_string, new_line_length) =
+                convert_srgb_channel_to_ppm_string(color_channel, line_length);
+            body.push_str(&channel_as_string);
+            (body, new_line_length)
+        },
+    )
+}
 
 pub fn canvas_to_ppm(canvas: &Canvas) -> String {
     let mut ppm_file = format!("{}\n", PPM_VERSION);
@@ -27,7 +97,32 @@ pub fn canvas_to_ppm(canvas: &Canvas) -> String {
         width = canvas.width,
         height = canvas.height
     ));
-    ppm_file.push_str(&format!("{}\n", MAX_COLOR_VALUE));
+    ppm_file.push_str(&format!("{}\n", MAX_SRGB_VALUE));
+
+    let (body, _) = build_ppm_string_from_pixels(&canvas.pixels, &canvas.width);
+
+    ppm_file.push_str(&body);
 
     ppm_file
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_srgb_scaling_returns_correct_value() {
+        assert_eq!(scale_to_srgb(Float::from(0.5)), 128);
+        assert_eq!(scale_to_srgb(Float::from(0.15)), 38);
+        assert_eq!(scale_to_srgb(Float::from(0.7)), 179);
+        assert_eq!(scale_to_srgb(Float::from(0.91)), 232);
+    }
+
+    #[test]
+    fn test_srgb_scaling_clamps_out_of_range_values() {
+        assert_eq!(scale_to_srgb(Float::from(-5.0)), 0);
+        assert_eq!(scale_to_srgb(Float::from(2.5)), 255);
+        assert_eq!(scale_to_srgb(Float::from(-0.01)), 0);
+        assert_eq!(scale_to_srgb(Float::from(1.01)), 255);
+    }
 }

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -16,3 +16,18 @@ pub fn pixel_at(canvas: &Canvas, x: usize, y: usize) -> Color {
     let index = x + (canvas.width * y);
     canvas.pixels[index]
 }
+
+const PPM_VERSION: &str = "P3";
+const MAX_COLOR_VALUE: u8 = 255;
+
+pub fn canvas_to_ppm(canvas: &Canvas) -> String {
+    let mut ppm_file = format!("{}\n", PPM_VERSION);
+    ppm_file.push_str(&format!(
+        "{width} {height}\n",
+        width = canvas.width,
+        height = canvas.height
+    ));
+    ppm_file.push_str(&format!("{}\n", MAX_COLOR_VALUE));
+
+    ppm_file
+}

--- a/src/graphics/color.rs
+++ b/src/graphics/color.rs
@@ -7,6 +7,12 @@ pub struct Color {
     pub blue: Float,
 }
 
+impl Color {
+    pub fn into_array(&self) -> [Float; 3] {
+        [self.red, self.green, self.blue]
+    }
+}
+
 impl PartialEq<Self> for Color {
     fn eq(&self, other: &Self) -> bool {
         self.red == other.red && self.green == other.green && self.blue == other.blue

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -1,8 +1,4 @@
-pub use crate::graphics::canvas::{
-    canvas_to_ppm,
-    pixel_at,
-    write_pixel,
-    Canvas};
+pub use crate::graphics::canvas::{canvas_to_ppm, pixel_at, write_pixel, Canvas};
 pub use crate::graphics::color::Color;
 use crate::Float;
 

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -1,6 +1,8 @@
-pub use crate::graphics::canvas::pixel_at;
-pub use crate::graphics::canvas::write_pixel;
-pub use crate::graphics::canvas::Canvas;
+pub use crate::graphics::canvas::{
+    canvas_to_ppm,
+    pixel_at,
+    write_pixel,
+    Canvas};
 pub use crate::graphics::color::Color;
 use crate::Float;
 

--- a/tests/canvas.rs
+++ b/tests/canvas.rs
@@ -149,7 +149,17 @@ fn assert_ppm_body_is_correct(world: &mut CanvasWorld, step: &Step) {
         .as_ref()
         .unwrap_or_else(|| panic!("Failed to get PPM output"));
 
-    assert!(actual_ppm_output.ends_with(expected_ppm_body));
+    assert!(actual_ppm_output.contains(expected_ppm_body));
+}
+
+#[then(regex = r"^ppm ends with a newline character$")]
+fn assert_ppm_body_ends_with_newline(world: &mut CanvasWorld) {
+    let actual_ppm_output = world
+        .output
+        .as_ref()
+        .unwrap_or_else(|| panic!("Failed to get PPM output"));
+
+    assert!(actual_ppm_output.ends_with('\n'));
 }
 
 fn main() {

--- a/tests/features/canvas.feature
+++ b/tests/features/canvas.feature
@@ -21,3 +21,19 @@ Scenario: Constructing the PPM header
   5 3
   255
   """
+
+Scenario: Constructing the PPM pixel data
+  Given c ← canvas(5, 3)
+  And c1 ← color(1.5, 0, 0)
+  And c2 ← color(0, 0.5, 0)
+  And c3 ← color(-0.5, 0, 1)
+  When write_pixel(c, 0, 0, c1)
+  And write_pixel(c, 2, 1, c2)
+  And write_pixel(c, 4, 2, c3)
+  And ppm ← canvas_to_ppm(c)
+  Then lines 4-6 of ppm are
+  """
+  255 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+  0 0 0 0 0 0 0 128 0 0 0 0 0 0 0
+  0 0 0 0 0 0 0 0 0 0 0 0 0 0 255
+  """

--- a/tests/features/canvas.feature
+++ b/tests/features/canvas.feature
@@ -11,3 +11,13 @@ Scenario: Writing pixels to a canvas
   And red ← color(1, 0, 0)
   When write_pixel(c, 2, 3, red)
   Then pixel_at(c, 2, 3) = red
+
+Scenario: Constructing the PPM header
+  Given c ← canvas(5, 3)
+  When ppm ← canvas_to_ppm(c)
+  Then lines 1-3 of ppm are
+  """
+  P3
+  5 3
+  255
+  """

--- a/tests/features/canvas.feature
+++ b/tests/features/canvas.feature
@@ -37,3 +37,8 @@ Scenario: Constructing the PPM pixel data
   0 0 0 0 0 0 0 128 0 0 0 0 0 0 0
   0 0 0 0 0 0 0 0 0 0 0 0 0 0 255
   """
+
+Scenario: PPM files are terminated by a newline character
+  Given c ← canvas(5, 3)
+  When ppm ← canvas_to_ppm(c)
+  Then ppm ends with a newline character


### PR DESCRIPTION
Context:
- output follows [PPM3](http://paulbourke.net/dataformats/ppm/) file format to render image

Changes:
- add ppm formatting related functions to canvas
- add ability to translate Color RGB channels to 8-bit integers
- move rayon to dependencies for array operations